### PR TITLE
fix: Use single ref for section list and flat list

### DIFF
--- a/src/list.tsx
+++ b/src/list.tsx
@@ -10,6 +10,7 @@ import React, {
   ReactElement,
   ReactNode,
   Ref,
+  RefObject,
   useCallback,
   useEffect,
   useMemo,
@@ -158,8 +159,9 @@ function ListComponent<S>({
   maintainVisibleContent,
   ...props
 }: ListProps<S>, ref?: ((instance: FlatList<S>|SectionList<S> | null) => void) | Ref<FlatList<S>> | Ref<SectionList<S>> | null) {
-  const sectionListRef = useCombinedRefs<SectionList<S>>([ref as Ref<SectionList<S>> || null])
-  const listRef = useCombinedRefs<FlatList<S>>([ref as Ref<FlatList<S>> || null])
+  const innerRef = useCombinedRefs<FlatList<S> | SectionList<S>>([(ref as any) || null])
+  const sectionListRef = innerRef as RefObject<SectionList<S>>
+  const listRef = innerRef as RefObject<FlatList<S>>
   const [visibleItems, setVisibleItems] = useState(items)
   const { getColor } = useTheme()
   const dividerColor = getColor?.(COLOR.DIVIDER)


### PR DESCRIPTION
#### Problem:
Since List component is using `useCombinedRef`, and as per current implementation `forwardedRef` is first being assigned to `sectionListRef` and then reassigned to `listRef`.

In [useCombinedRef](https://github.com/rintoj/native-x-list/blob/96254dc6129177adba1ef0de050508a7ad0ae4d4/src/utils.ts#L6), targetRef Is being assigned to ref and hence it is getting overwritten for `sectionListRef` and is not working.

#### Fix:
Using single ref works for both lists.
